### PR TITLE
Changing the hoverstates for the focus inbox items

### DIFF
--- a/N1-Taiga/styles/threads.less
+++ b/N1-Taiga/styles/threads.less
@@ -3,6 +3,14 @@
 .thread-list {
   .list-container {
     .list-item {
+      &.focused:hover .list-column-HoverActions .inner {
+        color: @taiga-dark !important;
+        background-image: linear-gradient(90deg, fadeout(@taiga-lighter, 100%) 0%, darken(@taiga-lighter, 10%) 100%);
+
+        .action {
+          -webkit-filter: none;
+        }
+      }
       .list-column {
         border-bottom: 0 !important;
       }


### PR DESCRIPTION
Tunneled deep inside Nylas, this errant background-image was offending.
##### Before

<img width="217" alt="screenshot 2015-12-10 18 01 46" src="https://cloud.githubusercontent.com/assets/987654/11734384/d209074e-9f84-11e5-830d-30bae86f90d1.png">
##### After

<img width="616" alt="screenshot 2015-12-10 21 28 41" src="https://cloud.githubusercontent.com/assets/987654/11734408/fecbe378-9f84-11e5-92cb-6ea2e064be84.png">
