### PR TITLE
Darken account name in sidebar

### DIFF
--- a/N1-Taiga/styles/sidebar.less
+++ b/N1-Taiga/styles/sidebar.less
@@ -1,5 +1,9 @@
 @import "variables";
 
+#account-switcher .primary-item .name {
+  color: @taiga-dark;
+}
+
 .account-sidebar-sections {
   background-color: @white !important;
 


### PR DESCRIPTION
I've been finding the account name in Taiga's sidebar be too light — it's the same light grey as the rest of the sidebar even though it's much more important. This PR just makes it `@taiga-dark`.

Before:
<img width="209" alt="screen shot 2015-12-18 at 11 22 35 am" src="https://cloud.githubusercontent.com/assets/5074763/11902176/ebf6e744-a57d-11e5-8d8d-2e8c6e95de0a.png">

After:
<img width="210" alt="screen shot 2015-12-18 at 11 53 48 am" src="https://cloud.githubusercontent.com/assets/5074763/11902199/0f6aff6c-a57e-11e5-9d8d-39b4762436fc.png">
