### PR TITLE
Support emphasized buttons

### DIFF
--- a/N1-Taiga/styles/controls.less
+++ b/N1-Taiga/styles/controls.less
@@ -11,6 +11,16 @@
   cursor: pointer !important;
 }
 
+.btn.btn-emphasis {
+  background-color: @taiga-accent !important;
+  border-color: @taiga-accent !important;
+  color: @white !important;
+
+  img.content-mask {
+    background-color: @white !important;
+  }
+}
+
 .button-dropdown.bordered {
   .primary-item {
     cursor: pointer !important;


### PR DESCRIPTION
There are a few "emphasized" buttons in N1 that are supposed to be bright blue, but Taiga has been leaving them white. This PR adds support for `.btn-emphasis` elements, including icons inside those buttons.

Before:
![screen shot 2015-12-21 at 12 31 04 am](https://cloud.githubusercontent.com/assets/5074763/11924122/83d27044-a77a-11e5-8fed-ba3b6d97f87e.png)

After:
![screen shot 2015-12-21 at 12 29 00 am](https://cloud.githubusercontent.com/assets/5074763/11924123/847dc854-a77a-11e5-9928-6dba55705cc4.png)
