### PR TITLE
Correct the Windows toolbar button's to have no border

### DIFF
--- a/N1-Taiga/styles/controls.less
+++ b/N1-Taiga/styles/controls.less
@@ -11,6 +11,14 @@
   cursor: pointer !important;
 }
 
+body.platform-win32 {
+  .sheet-toolbar-container {
+    .btn-toolbar {
+      border: 0 !important;
+    }
+  }
+}
+
 .btn.btn-emphasis {
   background-color: @taiga-accent !important;
   border-color: @taiga-accent !important;


### PR DESCRIPTION
For bug #17. This patch removes the borders previously set to all platforms and excludes Windows from the modification of `border`.

Before:
![2016-01-09-18-43-24_1280x1022](https://cloud.githubusercontent.com/assets/1266541/12219074/75077d48-b701-11e5-9b16-5d4f8e4f4aa1.png)

After:
![2016-01-09-18-43-52_1274x1022](https://cloud.githubusercontent.com/assets/1266541/12219075/79773bde-b701-11e5-8da6-1fe298297492.png)
