### PR TITLE
Fix stars and draft icons on focused messages

### DIFF
--- a/N1-Taiga/styles/threads.less
+++ b/N1-Taiga/styles/threads.less
@@ -10,6 +10,21 @@
         .action {
           -webkit-filter: none;
         }
+        .thread-icon {
+          &:not(.thread-icon-star) {
+            opacity: 0.7;
+          }
+        }
+      }
+      &.focused {
+        .thread-icon, .mail-important-icon {
+          -webkit-filter: none;
+        }
+      }
+      &:hover {
+        .thread-icon {
+          visibility: inherit;
+        }
       }
       .list-column {
         border-bottom: 0 !important;
@@ -40,6 +55,13 @@
           }
         }
       }
+    }
+  }
+  .thread-icon {
+    background-image: url(../static/images/thread-list/icon-star-hover-@2x.png);
+
+    &:not(.thread-icon-star) {
+      visibility: hidden;
     }
   }
 }

--- a/N1-Taiga/styles/threads.less
+++ b/N1-Taiga/styles/threads.less
@@ -17,7 +17,7 @@
         }
       }
       &.focused {
-        .thread-icon, .mail-important-icon {
+        .thread-icon, .mail-important-icon, .draft-icon {
           -webkit-filter: none;
         }
       }


### PR DESCRIPTION
The star and draft icon were difficult to see when a message was focused, both when the icon were active and inactive.

Before:
![before](https://cloud.githubusercontent.com/assets/10733271/12390629/043077ea-bde2-11e5-92ca-700275db5325.png)
![draft before](https://cloud.githubusercontent.com/assets/10733271/12391571/0832f064-bde9-11e5-92d5-da399c19efd9.png)
After:
![after](https://cloud.githubusercontent.com/assets/10733271/12390630/04344bfe-bde2-11e5-9c38-893a196f19ae.png)
![draft after](https://cloud.githubusercontent.com/assets/10733271/12391570/080f9286-bde9-11e5-9d00-b2835b33fe1a.png)

Resolves issue #22
