### PR TITLE
Add display name and colors for theme picker

### DIFF
--- a/N1-Taiga/package.json
+++ b/N1-Taiga/package.json
@@ -1,5 +1,6 @@
 {
   "name": "N1-Taiga",
+  "displayName": "Taiga",
   "theme": "Taiga",
   "version": "0.2.6",
   "description": "A clean, Mailbox-inspired theme for Nylas N1",

--- a/N1-Taiga/styles/theme-colors.less
+++ b/N1-Taiga/styles/theme-colors.less
@@ -1,0 +1,2 @@
+@component-active-color: #5dade1;
+@toolbar-background-color: #ddedf4;


### PR DESCRIPTION
Hey, Noah! I'm part of the Nylas team, and we're about to land a new visual theme picker that'll allow people to preview and view color palettes for themes. We pull a few major colors from the theme's UI variables to create the palette, but we've also added a way to override them manually with a `theme-colors.less` file for themes (like yours) that aren't conveyed well with the variables we selected.

Before:
<img width="113" alt="screen shot 2016-03-02 at 6 46 38 pm" src="https://cloud.githubusercontent.com/assets/8452682/13483188/209ba764-e0a7-11e5-9185-7ac195a12618.png">

After:
<img width="112" alt="screen shot 2016-03-02 at 6 46 01 pm" src="https://cloud.githubusercontent.com/assets/8452682/13483189/209bfe12-e0a7-11e5-8b7f-104cf427ea06.png">

Also, what are your thoughts on pulling everything into the root directory for the project? We've had a lot of people who are confused when they try to install using that directory (instead of `N1-Taiga/N1-Taiga`) and it doesn't work, and it might also be easier for them to `git pull` updates there. Just wanted to ask, but I get if you want to keep them separate, since they're logically distinct.
